### PR TITLE
Фельде Сергей ФИТ-231

### DIFF
--- a/SpaceBattle.Lib/Rotation/Angle.cs
+++ b/SpaceBattle.Lib/Rotation/Angle.cs
@@ -1,0 +1,34 @@
+﻿public class Angle
+{
+    private int num { get; set; }
+    private int den { get; }
+
+    public Angle(int num, int den)
+    {
+        this.den = den;
+        this.num = ((num % den) + den) % den;
+    }
+
+    public static Angle operator +(Angle ang1, Angle ang2)
+    {
+        return new Angle(ang1.num + ang2.num, ang1.den);
+    }
+
+    public override bool Equals(object? obj) => obj != null && obj is Angle angle && num == angle.num && den == angle.den;
+
+    public override int GetHashCode() => num.GetHashCode();
+
+    public static bool operator ==(Angle ang1, Angle ang2)
+    {
+        return ang1.Equals(ang2);
+    }
+
+    public static bool operator !=(Angle ang1, Angle ang2)
+    {
+        return !(ang1 == ang2);
+    }
+    public static implicit operator double(Angle angle)
+    {
+        return 2 * Math.PI * angle.num / angle.den;
+    }
+}

--- a/SpaceBattle.Lib/Rotation/RegisterIoCDependencyRotateCommand.cs
+++ b/SpaceBattle.Lib/Rotation/RegisterIoCDependencyRotateCommand.cs
@@ -1,0 +1,13 @@
+﻿namespace SpaceBattle.Lib;
+
+public class RegisterIoCDependencyRotateCommand : ICommand
+{
+    public void Execute()
+    {
+        IoC.Resolve<ICommand>(
+            "IoC.Register",
+            "Commands.Rotate",
+            (object[] args) => new RotateCommand(new RotatingAdapter((IDictionary<string, object>)args[0]))
+        ).Execute();
+    }
+}

--- a/SpaceBattle.Lib/Rotation/Rotate.cs
+++ b/SpaceBattle.Lib/Rotation/Rotate.cs
@@ -1,0 +1,20 @@
+﻿namespace SpaceBattle.Lib;
+
+public interface IRotating
+{
+    Angle AnglePos { get; set; }
+    Angle RotateVelocity { get; }
+}
+
+public class RotateCommand : ICommand
+{
+    private readonly IRotating obj;
+    public RotateCommand(IRotating obj)
+    {
+        this.obj = obj;
+    }
+    public void Execute()
+    {
+        obj.AnglePos = obj.AnglePos + obj.RotateVelocity;
+    }
+}

--- a/SpaceBattle.Lib/Rotation/RotatingAdapter.cs
+++ b/SpaceBattle.Lib/Rotation/RotatingAdapter.cs
@@ -1,0 +1,19 @@
+﻿namespace SpaceBattle.Lib;
+
+public class RotatingAdapter : IRotating
+{
+    private readonly IDictionary<string, object> _gameObject;
+
+    public RotatingAdapter(IDictionary<string, object> gameObject)
+    {
+        _gameObject = gameObject;
+    }
+
+    public Angle AnglePos
+    {
+        get => (Angle)_gameObject["AnglePos"];
+        set => _gameObject["AnglePos"] = value;
+    }
+
+    public Angle RotateVelocity => (Angle)_gameObject["RotateVelocity"];
+}

--- a/SpaceBattle.Tests/RotationTests/AngleTest.cs
+++ b/SpaceBattle.Tests/RotationTests/AngleTest.cs
@@ -1,0 +1,101 @@
+﻿namespace Spacebattle.Tests;
+
+public class AngleTests
+{
+    [Fact]
+    public void AngleSumTest()
+    {
+        var angle1 = new Angle(5, 8);
+        var angle2 = new Angle(7, 8);
+        Assert.Equal(new Angle(4, 8), angle1 + angle2);
+    }
+
+    [Fact]
+    public void AngleSum_WithOverflow_Test()
+    {
+        var angle1 = new Angle(7, 8);
+        var angle2 = new Angle(6, 8);
+        Assert.Equal(new Angle(5, 8), angle1 + angle2);
+    }
+
+    [Fact]
+    public void EqualsTest_ShouldReturnTrue()
+    {
+        var angle1 = new Angle(15, 8);
+        var angle2 = new Angle(23, 8);
+        Assert.True(angle1.Equals(angle2));
+    }
+
+    [Fact]
+    public void OperatorEqualsTest_ShouldReturnTrue()
+    {
+        var angle1 = new Angle(15, 8);
+        var angle2 = new Angle(23, 8);
+        Assert.True(angle1 == angle2);
+    }
+
+    [Fact]
+    public void EqualsTest_ShouldReturnFalse()
+    {
+        var angle1 = new Angle(1, 8);
+        var angle2 = new Angle(2, 8);
+        Assert.False(angle1.Equals(angle2));
+    }
+
+    [Fact]
+    public void OperatorNotEqualsTest_ShouldReturnTrue()
+    {
+        var angle1 = new Angle(1, 8);
+        var angle2 = new Angle(2, 8);
+        Assert.True(angle1 != angle2);
+    }
+
+    [Fact]
+    public void GetHashCode_ShouldReturnHashCode()
+    {
+        var angle = new Angle(1, 8);
+        Assert.NotEqual(0, angle.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_ShouldReturnFalse_ForNullObject()
+    {
+        var angle = new Angle(1, 8);
+        Assert.False(angle.Equals(null));
+    }
+
+    [Fact]
+    public void Equals_ShouldReturnFalse_ForNonAngleObject()
+    {
+        var angle = new Angle(1, 8);
+        Assert.False(angle.Equals("Не Angle"));
+    }
+
+    [Fact]
+    public void Sin_ShouldReturnCorrectValue()
+    {
+        var angle = new Angle(2, 8);
+        Assert.Equal(1.0, Math.Sin(angle), precision: 6);
+    }
+
+    [Fact]
+    public void Cos_ShouldReturnCorrectValue()
+    {
+        var angle = new Angle(2, 8);
+        Assert.Equal(0.0, Math.Cos(angle), precision: 6);
+    }
+
+    [Fact]
+    public void Constructor_ShouldNormalizeNegativeAngle()
+    {
+        var angle = new Angle(-1, 8);
+        Assert.Equal(new Angle(7, 8), angle);
+    }
+
+    [Fact]
+    public void Constructor_ShouldNormalizeOverflowAngle()
+    {
+        var angle = new Angle(9, 8);
+        Assert.Equal(new Angle(1, 8), angle);
+    }
+}

--- a/SpaceBattle.Tests/RotationTests/RegisterIoCDependencyRotateCommandTests.cs
+++ b/SpaceBattle.Tests/RotationTests/RegisterIoCDependencyRotateCommandTests.cs
@@ -1,0 +1,33 @@
+﻿using Hwdtech.Ioc;
+using SpaceBattle.Lib;
+
+namespace SpaceBattle.Tests
+{
+    public class RegisterIoCDependencyRotateCommandTests
+    {
+        public RegisterIoCDependencyRotateCommandTests()
+        {
+            new InitScopeBasedIoCImplementationCommand().Execute();
+            IoC.Resolve<ICommand>("Scopes.Current.Set",
+            IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
+        }
+
+        [Fact]
+        public void Execute_Should_Register_Rotate_Command_Dependency()
+        {
+            var gameObject = new Dictionary<string, object>
+            {
+                { "AnglePos", new Angle(90, 8) },
+                { "RotateVelocity", new Angle(45, 8) }
+            };
+
+            var cmd = new RegisterIoCDependencyRotateCommand();
+            cmd.Execute();
+
+            var rotateCommand = IoC.Resolve<ICommand>("Commands.Rotate", gameObject);
+            rotateCommand.Execute();
+
+            Assert.Equal(new Angle(135, 8), (Angle)gameObject["AnglePos"]);
+        }
+    }
+}

--- a/SpaceBattle.Tests/RotationTests/RotatingTest.cs
+++ b/SpaceBattle.Tests/RotationTests/RotatingTest.cs
@@ -1,0 +1,48 @@
+﻿using Moq;
+using SpaceBattle.Lib;
+namespace SpaceBattle.Tests;
+
+public class RotateCommandTestTest
+{
+    [Fact]
+    public void Rotating45DegreesWithVelocity90Test()
+    {
+        var rotatingObj = new Mock<IRotating>();
+        rotatingObj.SetupGet(x => x.AnglePos).Returns(new Angle(45, 8));
+        rotatingObj.SetupGet(x => x.RotateVelocity).Returns(new Angle(90, 8));
+        var cmd = new RotateCommand(rotatingObj.Object);
+        cmd.Execute();
+        rotatingObj.VerifySet(x => x.AnglePos = new Angle(135, 8));
+    }
+
+    [Fact]
+    public void NoAnglePosTest()
+    {
+        var rotatingObj = new Mock<IRotating>();
+        rotatingObj.SetupGet(x => x.AnglePos).Throws<Exception>();
+        rotatingObj.SetupGet(x => x.RotateVelocity).Returns(new Angle(90, 8));
+        var cmd = new RotateCommand(rotatingObj.Object);
+        Assert.Throws<Exception>(() => cmd.Execute());
+    }
+
+    [Fact]
+    public void NoRotateVelocityTest()
+    {
+        var rotatingObj = new Mock<IRotating>();
+        rotatingObj.SetupGet(x => x.AnglePos).Returns(new Angle(90, 8));
+        rotatingObj.SetupGet(x => x.RotateVelocity).Throws<Exception>();
+        var cmd = new RotateCommand(rotatingObj.Object);
+        Assert.Throws<Exception>(() => cmd.Execute());
+    }
+
+    [Fact]
+    public void CantChangeAnglePosTest()
+    {
+        var rotatingObj = new Mock<IRotating>();
+        rotatingObj.SetupGet(x => x.AnglePos).Returns(new Angle(0, 8));
+        rotatingObj.SetupSet(x => x.AnglePos = It.IsAny<Angle>()).Throws<Exception>();
+        rotatingObj.SetupGet(x => x.RotateVelocity).Returns(new Angle(848, 8));
+        var cmd = new RotateCommand(rotatingObj.Object);
+        Assert.Throws<Exception>(() => cmd.Execute());
+    }
+}


### PR DESCRIPTION
7. Угол на плоскости.
Для представления угла наклона к оси OX игрового объекта реализовать класс Angle. Внутри Angle представлен как рациональное число, причем знаменатель у всех углов будет одинаковый (его можно сделать статическим полем). Для угла должна быть реализована операция сложения и должна быть возможность вычисления синуса и косинуса от Angle без предварительного явного приведения к типу Double: Math.Cos(angle).

Критерии приемки:

Реализован тест, который проверяет, что при сложении углов (5, 8) и (7, 8) получается вектор (4,8).
Реализован тест, который проверят, что два угла (15, 8) и (23, 8), равны между собой при сравнении через метод Equals.
Реализован тест, который проверят, что два угла (15, 8) и (23, 8), равны между собой при сравнении через метод ==.
Реализован тест, который проверят, что углы (1,8) и (2, 8) неравны между собой при сравнении через метод Equals.
Реализован тест, который проверят, что углы (1,8) и (2, 8) неравны между собой при сравнении через метод !=.
Реализован тест, который проверяет наличие хэш-кода у угла.

8. Определить команду Rotate для равномерного вращения вокруг собственной оси.
Команда выполняет равномерное поступальное движение объекта без деформации за один дискретный момент времени.

Критерии приемки:

Реализован тест, который проверяет, что если вращающийся объект имеет угол наклона 45 градусов к оси OX и имеет мгновенную угловую скорость скорость 45 градусов, то в следующий дискретный момент времени угол наклона к оси OX будет 90 градусов.
Реализован тест, который проверяет, что если невозможно определить угол наклона объекта к оси OX, то команда Rotate выбрасывает исключение.
Реализован тест, который проверяет, что если у вращающегося объекта невозможно определить мгновенную угловую скорость, то команда Rotate выбрасывает исключение.
Реализован тест, который проверяет, что еcли у движущегося объекта невозможно изменить угол наклона к оси OX, то команда Rotate выбрасывает исключение.

9. Регистрация зависимости Commands.Rotate в IoC.
Зарегистрировать зависимость "Commands.Rotate" в IoC, с помощью которой можно разрешить команду MoveCommand по игровому объекту. Для регистрации зависимости определить отдельную команду с префиксом RegisterIoCDependency:

public class RegisterIoCDependencyRotateCommand : ICommand
{
    public void Execute()
  {
      // код, регистрирующий зависимость
    }
}
Примечание: Для того, чтобы создать RotateCommand, необходимо создать адаптер IDictionary<string, object> для интерфейса IRotatingObject. Задача конструирования Адаптеров по интерфейсу будет рассмотрена в другой лабораторной работе, поэтому в данной задаче используйте разрешение зависимости Ioc.Resolve("Adapters.IRotatingObject", obj), где obj - игровой объект. В тестах используйте Mock-объекты, для разрешения этой зависимости.

Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterIoCDependencyRotateCommand зависимость разрешается.