### PR TITLE
Мельников Максим ФИТ 231

### DIFF
--- a/SpaceBattle.Lib/Commands/InjectableCommand.cs
+++ b/SpaceBattle.Lib/Commands/InjectableCommand.cs
@@ -1,0 +1,21 @@
+﻿namespace SpaceBattle.Lib;
+
+public class InjectableCommand : ICommand, ICommandInjectable
+{
+    private ICommand? _cmd;
+
+    public void Execute()
+    {
+        if (_cmd == null)
+        {
+            throw new InvalidOperationException("No command injected.");
+        }
+
+        _cmd.Execute();
+    }
+
+    public void Inject(ICommand cmd)
+    {
+        _cmd = cmd;
+    }
+}

--- a/SpaceBattle.Lib/Commands/RegisterDependencyCommandInjectableCommand.cs
+++ b/SpaceBattle.Lib/Commands/RegisterDependencyCommandInjectableCommand.cs
@@ -1,0 +1,15 @@
+﻿namespace SpaceBattle.Lib;
+
+using Hwdtech;
+
+public class RegisterDependencyCommandInjectableCommand : ICommand
+{
+    public void Execute()
+    {
+        IoC.Resolve<ICommand>(
+            "IoC.Register",
+            "Commands.CommandInjectable",
+            (object[] args) => new InjectableCommand()
+        ).Execute();
+    }
+}

--- a/SpaceBattle.Lib/Interfaces/Injectable.cs
+++ b/SpaceBattle.Lib/Interfaces/Injectable.cs
@@ -1,0 +1,7 @@
+﻿namespace SpaceBattle.Lib;
+
+public interface ICommandInjectable
+
+{
+    void Inject(ICommand cmd);
+}

--- a/SpaceBattle.Tests/CommandTests/InjectableCommandTest.cs
+++ b/SpaceBattle.Tests/CommandTests/InjectableCommandTest.cs
@@ -1,0 +1,27 @@
+﻿using Moq;
+using SpaceBattle.Lib;
+
+namespace SpaceBattle.Tests;
+
+public class InjectableCommandTest
+{
+    [Fact]
+    public void InjectableCommand_ThrowsException_WhenNotInjected()
+    {
+        var injectable = new InjectableCommand();
+
+        Assert.Throws<InvalidOperationException>(() => injectable.Execute());
+    }
+
+    [Fact]
+    public void InjectableCommand_ExecutesInjectedCommand()
+    {
+        var injectable = new InjectableCommand();
+        var cmd = new Mock<ICommand>();
+
+        injectable.Inject(cmd.Object);
+        injectable.Execute();
+
+        cmd.Verify(x => x.Execute(), Times.Once());
+    }
+}

--- a/SpaceBattle.Tests/CommandTests/RegisterDependencyCommandInjectableCommandTests.cs
+++ b/SpaceBattle.Tests/CommandTests/RegisterDependencyCommandInjectableCommandTests.cs
@@ -1,0 +1,30 @@
+﻿using Hwdtech.Ioc;
+using Moq;
+using SpaceBattle.Lib;
+
+namespace SpaceBattle.Tests;
+
+public class RegisterDependencyCommandInjectableCommandTests
+{
+    public RegisterDependencyCommandInjectableCommandTests()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        IoC.Resolve<ICommand>("Scopes.Current.Set",
+        IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
+    }
+
+    [Fact]
+    public void RegisterDependencyCommandInjectableCommand_Success()
+    {
+        new RegisterDependencyCommandInjectableCommand().Execute();
+
+        var cmd1 = IoC.Resolve<ICommand>("Commands.CommandInjectable");
+        var cmd2 = IoC.Resolve<ICommandInjectable>("Commands.CommandInjectable");
+        var cmd3 = IoC.Resolve<InjectableCommand>("Commands.CommandInjectable");
+
+        var cmd = new Mock<ICommand>();
+        ((ICommandInjectable)cmd1).Inject(cmd.Object);
+        cmd1.Execute();
+        cmd.Verify(c => c.Execute(), Times.Once());
+    }
+}


### PR DESCRIPTION
16. Определить интерфейс ICommandInjectable
public interface ICommandInjectable
{
    void Inject(ICommand command);
}

17. Определить команду CommandInjectableCommand
Команда реализует два интерфейса ICommand и ICommandIjectable.

Критерии приемки:

Реализован тест, который проверяет, что после того как команда будет внедрена в объект класса CommandInjectableCommand, то она будет вызвана при выполнении метода Execute объекта класса CommandInjectableCommand.
Реализован тест, который проверяет, что вызов Execute класса CommandInjectableCommand выбрасывает исключение, если не была внедерена команда.

18. Определить зависимость "Commands.CommandInjectable" в IoC, которая конструирует команду CommandInjectableCommand.
Указание: Для регистрации зависимости определить команду RegisterMacroCommand:

public class RegisterDependencyCommandInjectableCommand : ICommand
{
    public void Execute()
  {
      // код, регистрирующий зависимость
    }
}
Критерии приемки:

Реализован тест, который проверяет, что следующий код работает без выброса исключений:
Ioc.Resolve<ICommand>("Commands.CommadInjectable");
Ioc.Resolve<ICommandInjectable>("Commands.CommadInjectable");
Ioc.Resolve<CommandInjectableCommand>("Commands.CommadInjectable");