### PR TITLE
Кондаков Николай ФИТ-231

### DIFF
--- a/SpaceBattle.Lib/Commands/CreateMacroCommandStrategy.cs
+++ b/SpaceBattle.Lib/Commands/CreateMacroCommandStrategy.cs
@@ -1,0 +1,19 @@
+﻿namespace SpaceBattle.Lib
+{
+    public class CreateMacroCommandStrategy
+    {
+        private readonly string cmdSpec;
+
+        public CreateMacroCommandStrategy(string cmdSpec)
+        {
+            this.cmdSpec = cmdSpec;
+        }
+
+        public ICommand Resolve(object[] args)
+        {
+            var cmdsNames = IoC.Resolve<string[]>($"Specs.{cmdSpec}");
+            var cmds = cmdsNames.Select(name => IoC.Resolve<ICommand>(name, args)).ToArray();
+            return IoC.Resolve<ICommand>("Commands.Macro", cmds.Cast<object>().ToArray());
+        }
+    }
+}

--- a/SpaceBattle.Lib/Commands/RegisterIoCDependencyMacroCommand.cs
+++ b/SpaceBattle.Lib/Commands/RegisterIoCDependencyMacroCommand.cs
@@ -1,0 +1,13 @@
+﻿namespace SpaceBattle.Lib
+{
+    public class RegisterIoCDependencyMacroCommand : ICommand
+    {
+        public void Execute()
+        {
+            IoC.Resolve<ICommand>(
+                "IoC.Register",
+                "Commands.Macro",
+                (object[] args) => (ICommand)new SimpleMacroCommand(args.Select(x => (ICommand)x).ToArray())).Execute();
+        }
+    }
+}

--- a/SpaceBattle.Lib/Commands/RegisterIoCDependencyMacroMoveRotate.cs
+++ b/SpaceBattle.Lib/Commands/RegisterIoCDependencyMacroMoveRotate.cs
@@ -1,0 +1,20 @@
+﻿namespace SpaceBattle.Lib
+{
+    public class RegisterIoCDependencyMacroMoveRotate : ICommand
+    {
+        public void Execute()
+        {
+            IoC.Resolve<ICommand>(
+                "IoC.Register",
+                "Macro.Move",
+                (object[] args) => new CreateMacroCommandStrategy("Move").Resolve(args)
+            ).Execute();
+
+            IoC.Resolve<ICommand>(
+                "IoC.Register",
+                "Macro.Rotate",
+                (object[] args) => new CreateMacroCommandStrategy("Rotate").Resolve(args)
+            ).Execute();
+        }
+    }
+}

--- a/SpaceBattle.Lib/Commands/SimpleMacroCommand.cs
+++ b/SpaceBattle.Lib/Commands/SimpleMacroCommand.cs
@@ -1,0 +1,16 @@
+﻿namespace SpaceBattle.Lib;
+public class SimpleMacroCommand : ICommand
+{
+    public ICommand[] cmds;
+    public SimpleMacroCommand(params ICommand[] cmds)
+    {
+        this.cmds = cmds;
+    }
+    public void Execute()
+    {
+        foreach (var cmd in cmds)
+        {
+            cmd.Execute();
+        }
+    }
+}

--- a/SpaceBattle.Tests/CommandTests/CreateMacroCommandStrategyTests.cs
+++ b/SpaceBattle.Tests/CommandTests/CreateMacroCommandStrategyTests.cs
@@ -1,0 +1,52 @@
+﻿using Hwdtech.Ioc;
+using Moq;
+using SpaceBattle.Lib;
+
+namespace SpaceBattle.Tests
+{
+    public class CreateMacroCommandStrategyTests
+    {
+        public CreateMacroCommandStrategyTests()
+        {
+            new InitScopeBasedIoCImplementationCommand().Execute();
+            IoC.Resolve<ICommand>("Scopes.Current.Set",
+                IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))
+            ).Execute();
+        }
+
+        [Fact]
+        public void Resolve_Should_Create_MacroCommand_When_Dependency_Exists()
+        {
+            var cmd1 = new Mock<ICommand>();
+            var cmd2 = new Mock<ICommand>();
+
+            IoC.Resolve<ICommand>("IoC.Register", "Specs.Test", (object[] args) => new string[] { "Command1", "Command2" }).Execute();
+
+            IoC.Resolve<ICommand>("IoC.Register", "Command1", (object[] args) => cmd1.Object).Execute();
+
+            IoC.Resolve<ICommand>("IoC.Register", "Command2", (object[] args) => cmd2.Object).Execute();
+
+            var regMacroCommand = new RegisterIoCDependencyMacroCommand();
+            regMacroCommand.Execute();
+
+            var strategy = new CreateMacroCommandStrategy("Test");
+            strategy.Resolve(new object[] { }).Execute();
+
+            cmd1.Verify(m => m.Execute(), Times.Once());
+            cmd2.Verify(m => m.Execute(), Times.Once());
+        }
+
+        [Fact]
+        public void Resolve_Should_Throw_When_Command_Dependency_Not_Exists()
+        {
+            IoC.Resolve<ICommand>("IoC.Register", "Specs.Test", (object[] args) => new string[] { "Rofls" }).Execute();
+
+            new RegisterIoCDependencyMacroCommand().Execute();
+
+            var strategy = new CreateMacroCommandStrategy("Test");
+            var args = new object[] { };
+
+            Assert.Throws<ArgumentException>(() => strategy.Resolve(args));
+        }
+    }
+}

--- a/SpaceBattle.Tests/CommandTests/RegisterIoCDependencyMacroCommandTests.cs
+++ b/SpaceBattle.Tests/CommandTests/RegisterIoCDependencyMacroCommandTests.cs
@@ -1,0 +1,32 @@
+﻿using Hwdtech.Ioc;
+using Moq;
+using SpaceBattle.Lib;
+
+namespace SpaceBattle.Tests
+{
+    public class RegisterIoCDependencyMacroCommandTests
+    {
+        public RegisterIoCDependencyMacroCommandTests()
+        {
+            new InitScopeBasedIoCImplementationCommand().Execute();
+            IoC.Resolve<ICommand>("Scopes.Current.Set",
+            IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
+        }
+
+        [Fact]
+        public void Execute_Should_Register_Macro_Command_Dependency()
+        {
+            var cmd1 = new Mock<ICommand>();
+            var cmd2 = new Mock<ICommand>();
+
+            var cmd = new RegisterIoCDependencyMacroCommand();
+            cmd.Execute();
+
+            var macroCommand = IoC.Resolve<ICommand>("Commands.Macro", new ICommand[] { cmd1.Object, cmd2.Object });
+            macroCommand.Execute();
+
+            cmd1.Verify(m => m.Execute(), Times.Once());
+            cmd2.Verify(m => m.Execute(), Times.Once());
+        }
+    }
+}

--- a/SpaceBattle.Tests/CommandTests/RegisterIoCDependencyMacroMoveRotateTests.cs
+++ b/SpaceBattle.Tests/CommandTests/RegisterIoCDependencyMacroMoveRotateTests.cs
@@ -1,0 +1,42 @@
+﻿using Hwdtech.Ioc;
+using Moq;
+using SpaceBattle.Lib;
+
+namespace SpaceBattle.Tests
+{
+    public class RegisterIoCDependencyMacroMoveRotateTests
+    {
+        public RegisterIoCDependencyMacroMoveRotateTests()
+        {
+            new InitScopeBasedIoCImplementationCommand().Execute();
+            IoC.Resolve<ICommand>("Scopes.Current.Set",
+            IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
+        }
+
+        [Fact]
+        public void MacroMoveRotate_Dependencies_Should_Be_Registered()
+        {
+            var cmd1 = new Mock<ICommand>();
+            var cmd2 = new Mock<ICommand>();
+
+            IoC.Resolve<ICommand>("IoC.Register", "Specs.Move",
+                (object[] args) => new string[] { "Command1", "Command2" }).Execute();
+
+            IoC.Resolve<ICommand>("IoC.Register", "Command1",
+                (object[] args) => cmd1.Object).Execute();
+
+            IoC.Resolve<ICommand>("IoC.Register", "Command2",
+                (object[] args) => cmd2.Object).Execute();
+
+            IoC.Resolve<ICommand>("IoC.Register", "Specs.Rotate",
+                (object[] args) => new string[] { "Command1", "Command2" }).Execute();
+
+            new RegisterIoCDependencyMacroCommand().Execute();
+            new RegisterIoCDependencyMacroMoveRotate().Execute();
+            IoC.Resolve<ICommand>("Macro.Move").Execute();
+
+            cmd1.Verify(c => c.Execute());
+            cmd2.Verify(c => c.Execute());
+        }
+    }
+}

--- a/SpaceBattle.Tests/CommandTests/SimpleMacroCommandTests.cs
+++ b/SpaceBattle.Tests/CommandTests/SimpleMacroCommandTests.cs
@@ -1,0 +1,25 @@
+﻿using Moq;
+using SpaceBattle.Lib;
+
+namespace SpaceBattle.Tests
+{
+    public class SimpleMacroCommandTests
+    {
+        [Fact]
+        public void Execute_Should_Stop_On_Exception()
+        {
+            var cmd1 = new Mock<ICommand>();
+            var cmd2 = new Mock<ICommand>();
+            var cmd3 = new Mock<ICommand>();
+
+            cmd2.Setup(m => m.Execute()).Throws<Exception>();
+
+            var macroCommand = new SimpleMacroCommand(cmd1.Object, cmd2.Object, cmd3.Object);
+
+            Assert.Throws<Exception>(() => macroCommand.Execute());
+            cmd1.Verify(m => m.Execute(), Times.Once());
+            cmd2.Verify(m => m.Execute(), Times.Once());
+            cmd3.Verify(m => m.Execute(), Times.Never());
+        }
+    }
+}


### PR DESCRIPTION
9. Регистрация зависимости Commands.Rotate в IoC.
Зарегистрировать зависимость "Commands.Rotate" в IoC, с помощью которой можно разрешить команду MoveCommand по игровому объекту. Для регистрации зависимости определить отдельную команду с префиксом RegisterIoCDependency:

Примечание: Для того, чтобы создать RotateCommand, необходимо создать адаптер IDictionary<string, object> для интерфейса IRotatingObject. Задача конструирования Адаптеров по интерфейсу будет рассмотрена в другой лабораторной работе, поэтому в данной задаче используйте разрешение зависимости Ioc.Resolve("Adapters.IRotatingObject", obj), где obj - игровой объект. В тестах используйте Mock-объекты, для разрешения этой зависимости.

Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterIoCDependencyRotateCommand зависимость разрешается.

14. Определить команду SendCommand для отправки команды.
SendCommand в конструктор получает команду ICommand и интерфейс ICommandReceiver. В методе Execute SendCommand вызывается метод Receive интерфейса ICommandReceiver, в который передается длительная команда.

Критерии приемки:

Реализован тест "SendCommand передает команду в IMessageReceiver", который проверяет, что при вызове метода Execute класса SendCommand вызывается метод Receive объекта ICommandReceiver с параметром - объектом длительной команды.
Реализован тест, который проверяет, что SendCommand.Execute выбрасывает исключение, если IMessageReceiver не может принять длительную команду.

15. Определить зависимость "Commands.Send" в IoC, которая по команде и объекту типа IMessageReceiver конструирует команду SendCommand.
Указание: Для регистрации зависимости определить команду RegisterIoCDependencySendCommand:

Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterDependencySendCommand зависимость разрешается.

18. Определить зависимость "Commands.CommandInjectable" в IoC, которая конструирует команду CommandInjectableCommand.
Указание: Для регистрации зависимости определить команду RegisterMacroCommand:

Критерии приемки:

Реализован тест, который проверяет, что следующий код работает без выброса исключений:
Ioc.Resolve<ICommand>("Commands.CommadInjectable");
Ioc.Resolve<ICommandInjectable>("Commands.CommadInjectable");
Ioc.Resolve<CommandInjectableCommand>("Commands.CommadInjectable");